### PR TITLE
Workaround for the fontSize isse

### DIFF
--- a/samples/Append.Blazor.Printing.Wasm/wwwroot/examples/Example.md
+++ b/samples/Append.Blazor.Printing.Wasm/wwwroot/examples/Example.md
@@ -12,8 +12,6 @@
     [Parameter] public RenderFragment Documentation { get; set; }
     [Parameter] public RenderFragment Code { get; set; }
     [Parameter] public string Name { get; set; }
-    private string id => Guid.NewGuid().ToString();
-
     private string sampleCode;
 
     protected override async Task OnParametersSetAsync()

--- a/source/Append.Blazor.Printing/PrintOptions.cs
+++ b/source/Append.Blazor.Printing/PrintOptions.cs
@@ -14,12 +14,13 @@
             Printable = printable;
         }
 
-        public PrintOptions(string printable, string modalMessage, PrintType printType = PrintType.Pdf)
+        public PrintOptions(string printable, string modalMessage, PrintType printType = PrintType.Pdf, bool useFontSizeWorkaround = false)
         {
             Printable = printable;
             ModalMessage = modalMessage;
             ShowModal = true;
             Type = printType;
+            UseFontSizeWorkaround = useFontSizeWorkaround;
         }
         /// <summary>
         /// Document source: pdf url or base64.
@@ -41,5 +42,10 @@
         /// Used when printing PDF documents passed as base64 data.
         /// </summary>
         public bool Base64 { get; set; }
+
+        /// <summary>
+        /// Uses empty font_size parameter as a workaround for issue https://github.com/crabbly/Print.js/issues/534.
+        /// </summary>
+        public bool UseFontSizeWorkaround { get; set; }
     }
 }

--- a/source/Append.Blazor.Printing/PrintOptionsAdapter.cs
+++ b/source/Append.Blazor.Printing/PrintOptionsAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Append.Blazor.Printing
 {
@@ -13,6 +14,9 @@ namespace Append.Blazor.Printing
         public string ModalMessage { get; init; } = "Retrieving Document...";
         public bool? Base64 { get; set; }
         public string TargetStyles { get; set; } = "['*']";
+        [JsonPropertyName("font_size")]
+        //HACK: This is a hack to get around the fact that the PrintJS is dead and issue https://github.com/crabbly/Print.js/issues/534 is not getting fixed anytime soon.
+        public string FontSize { get; set; }
 
         public PrintOptionsAdapter(PrintOptions options)
         {
@@ -21,6 +25,7 @@ namespace Append.Blazor.Printing
             ShowModal = options.ShowModal;
             ModalMessage = options.ModalMessage;
             Base64 = options.Base64 == true ? true : null;
+            FontSize = options.UseFontSizeWorkaround ? "" : "12px"; //12px is the default value in PrintJS
         }
     }
 }


### PR DESCRIPTION
See issue https://github.com/crabbly/Print.js/issues/534 for explanation. This PR implements a workaround mentioned in the issue, it needs to be tested more though.