### PR TITLE
Expose documentTitle option from PrintJS

### DIFF
--- a/source/Append.Blazor.Printing/PrintOptions.cs
+++ b/source/Append.Blazor.Printing/PrintOptions.cs
@@ -30,6 +30,10 @@
         /// </summary>
         public PrintType Type { get; init; }
         /// <summary>
+        /// When printing html, image or json, this will be shown as the document title.
+        /// </summary>
+        public string DocumentTitle { get; set; } = "Document";
+        /// <summary>
         /// Enable this option to show user feedback when retrieving or processing large PDF files.
         /// </summary>
         public bool ShowModal { get; init; }

--- a/source/Append.Blazor.Printing/PrintOptionsAdapter.cs
+++ b/source/Append.Blazor.Printing/PrintOptionsAdapter.cs
@@ -9,6 +9,7 @@ namespace Append.Blazor.Printing
     {
         public string Printable { get; init; }
         public string Type { get; init; }
+        public string DocumentTitle { get; set; } = "Document";
         public bool ShowModal { get; init; }
         public string ModalMessage { get; init; } = "Retrieving Document...";
         public bool? Base64 { get; set; }
@@ -18,6 +19,8 @@ namespace Append.Blazor.Printing
         {
             Printable = options.Printable;
             Type = options.Type.ToPrintJsString();
+            if (!string.IsNullOrWhiteSpace(options.DocumentTitle))
+                DocumentTitle = options.DocumentTitle;
             ShowModal = options.ShowModal;
             ModalMessage = options.ModalMessage;
             Base64 = options.Base64 == true ? true : null;


### PR DESCRIPTION
PrintJS has an option `documentTitle` which wasn't exposed by Blazor.Printing.
While this option does not set default name for PDF when using "Save as PDF" in all browsers, it _does_ in FireFox.
Also, this option does have an effect for all browsers; it changes the title shown in the header and some end-users might want to include headers and footers when printing.

Because this option might not be as useful for everyone, I've didn't add to a constructor of `PrintOptions` but I do think it's useful to expose `documentTitle` for those who want to use it.

See also this comment: https://github.com/crabbly/Print.js/issues/696#issuecomment-2345567095

Relates to: https://github.com/Append-IT/Blazor.Printing/issues/25