### PR TITLE
Fix by default

### DIFF
--- a/Append.Blazor.Printing.sln
+++ b/Append.Blazor.Printing.sln
@@ -9,7 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{54F3
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Append.Blazor.Printing.Documentation", "samples\Append.Blazor.Printing.Wasm\Append.Blazor.Printing.Documentation.csproj", "{257B37E3-2055-474F-8BBB-B60A90838D3F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Append.Blazor.Printing", "source\Append.Blazor.Printing\Append.Blazor.Printing.csproj", "{757DD656-436F-46C4-8FCE-5A6B9D3337F1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Append.Blazor.Printing.Patched", "source\Append.Blazor.Printing\Append.Blazor.Printing.Patched.csproj", "{757DD656-436F-46C4-8FCE-5A6B9D3337F1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Append.Blazor.Printing.Server", "samples\Append.Blazor.Printing.Server\Append.Blazor.Printing.Server.csproj", "{52F912F5-3BA6-404E-9FFB-72EF1C6E5544}"
 EndProject

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Documentation and examples can be found [here](https://blazor-printing.append.be
 
 ### Installing
 
-You can install from NuGet using the following command:
+You can install from [NuGet](https://www.nuget.org/packages/Append.Blazor.Printing.Patched/6.3.1) using the following command:
 
-`Install-Package Append.Blazor.Printing`
+`Install-Package Append.Blazor.Printing.Patched`
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is a fork of the Append.Blazor.Printing package provided by [Append-IT](https://github.com/Append-IT) which currently fixes font sizes on printing. Below is from the original repository.
 Print and Save files in Blazor using the native dialog box using JavaScript Interop and [PrintJS](https://printjs.crabbly.com/).
 
-![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/azauditor.Blazor.Printing?style=flat-square)
+![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/Append.Blazor.Printing.Patched?style=flat-square)
 
 ## The result
 ![Screenshot](https://i.imgur.com/a0O6zwE.gif)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Blazor Printing
+This is a fork of the Append.Blazor.Printing package provided by [Append-IT](https://github.com/Append-IT) which currently fixes font sizes on printing. Below is from the original repository.
 Print and Save files in Blazor using the native dialog box using JavaScript Interop and [PrintJS](https://printjs.crabbly.com/).
 
-![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/Append.Blazor.Printing?style=flat-square)
+![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/azauditor.Blazor.Printing?style=flat-square)
 
 ## The result
 ![Screenshot](https://i.imgur.com/a0O6zwE.gif)

--- a/samples/Append.Blazor.Printing.Server/Append.Blazor.Printing.Server.csproj
+++ b/samples/Append.Blazor.Printing.Server/Append.Blazor.Printing.Server.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\source\Append.Blazor.Printing\Append.Blazor.Printing.csproj" />
+    <ProjectReference Include="..\..\source\Append.Blazor.Printing\Append.Blazor.Printing.Patched.csproj" />
   </ItemGroup>
 
 </Project>

--- a/source/Append.Blazor.Printing/Append.Blazor.Printing.Patched.csproj
+++ b/source/Append.Blazor.Printing/Append.Blazor.Printing.Patched.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>6.3.0</Version>
-    <Authors>Benjamin Vertonghen</Authors>
-    <Company>Append</Company>
+    <Version>6.3.1</Version>
+    <Authors>Benjamin Vertonghen, Luk164, Taylor Dietz, Hans Husurianto</Authors>
+    <Company>Arizona Auditor General</Company>
     <Description>Print and Save files in Blazor using the native dialog box using JavaScript Interop.</Description>
-    <PackageProjectUrl>https://github.com/Append-IT/Append.Blazor.Printing</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Append-IT/Append.Blazor.Printing</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/azauditor/Blazor.Printing</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/azauditor/Blazor.Printing</RepositoryUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 

--- a/source/Append.Blazor.Printing/Append.Blazor.Printing.Patched.csproj
+++ b/source/Append.Blazor.Printing/Append.Blazor.Printing.Patched.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>6.3.1</Version>
+    <Version>6.3.2</Version>
     <Authors>Benjamin Vertonghen, Luk164, Taylor Dietz, Hans Husurianto</Authors>
     <Company>Arizona Auditor General</Company>
     <Description>Print and Save files in Blazor using the native dialog box using JavaScript Interop.</Description>

--- a/source/Append.Blazor.Printing/PrintOptions.cs
+++ b/source/Append.Blazor.Printing/PrintOptions.cs
@@ -41,5 +41,9 @@
         /// Used when printing PDF documents passed as base64 data.
         /// </summary>
         public bool Base64 { get; set; }
+        /// <summary>
+        /// Font size to use when printing. Default is 12px
+        /// </summary>
+        public string FontSize { get; set; } = "12px";
     }
 }

--- a/source/Append.Blazor.Printing/PrintOptions.cs
+++ b/source/Append.Blazor.Printing/PrintOptions.cs
@@ -44,6 +44,6 @@
         /// <summary>
         /// Font size to use when printing. Default is 12px
         /// </summary>
-        public string FontSize { get; set; } = "12px";
+        public string FontSize { get; set; } = "";
     }
 }

--- a/source/Append.Blazor.Printing/PrintOptionsAdapter.cs
+++ b/source/Append.Blazor.Printing/PrintOptionsAdapter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Text.Json.Serialization;
 
 namespace Append.Blazor.Printing
 {
@@ -13,6 +13,8 @@ namespace Append.Blazor.Printing
         public string ModalMessage { get; init; } = "Retrieving Document...";
         public bool? Base64 { get; set; }
         public string TargetStyles { get; set; } = "['*']";
+        [JsonPropertyName("font_size")]
+        public string FontSize { get; set; } = "12px";
 
         public PrintOptionsAdapter(PrintOptions options)
         {
@@ -21,6 +23,7 @@ namespace Append.Blazor.Printing
             ShowModal = options.ShowModal;
             ModalMessage = options.ModalMessage;
             Base64 = options.Base64 == true ? true : null;
+            FontSize = options.FontSize;
         }
     }
 }

--- a/source/Append.Blazor.Printing/PrintOptionsAdapter.cs
+++ b/source/Append.Blazor.Printing/PrintOptionsAdapter.cs
@@ -14,7 +14,7 @@ namespace Append.Blazor.Printing
         public bool? Base64 { get; set; }
         public string TargetStyles { get; set; } = "['*']";
         [JsonPropertyName("font_size")]
-        public string FontSize { get; set; } = "12px";
+        public string FontSize { get; set; } = "";
 
         public PrintOptionsAdapter(PrintOptions options)
         {

--- a/source/Append.Blazor.Printing/PrintingService.cs
+++ b/source/Append.Blazor.Printing/PrintingService.cs
@@ -32,7 +32,7 @@ namespace Append.Blazor.Printing
 
         internal async ValueTask ImportModule()
         {
-            module = await jsRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/Append.Blazor.Printing/scripts.js");
+            module = await jsRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/Append.Blazor.Printing.Patched/scripts.js");
         }
     }
 }

--- a/source/Append.Blazor.Printing/PrintingService.cs
+++ b/source/Append.Blazor.Printing/PrintingService.cs
@@ -1,10 +1,4 @@
 ﻿using Microsoft.JSInterop;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Append.Blazor.Printing
@@ -33,7 +27,7 @@ namespace Append.Blazor.Printing
         }
         public Task Print(string printable, bool showModal, PrintType printType = PrintType.Pdf)
         {
-            return Print(new PrintOptions(printable) { ShowModal= showModal, Type = printType });
+            return Print(new PrintOptions(printable) { ShowModal = showModal, Type = printType });
         }
 
         internal async ValueTask ImportModule()


### PR DESCRIPTION
now uses your css font sizes by default. the old behavior can be accessed by setting FontSize="12px" in PrintOptions